### PR TITLE
Updating python version in tutorial

### DIFF
--- a/docs/source/tutorials/genpipes_tutorial.rst
+++ b/docs/source/tutorials/genpipes_tutorial.rst
@@ -27,7 +27,7 @@ paste the following lines of code and save the file and Exit (Control + X):
     ## GenPipes/MUGQIC genomes and modules
     export MUGQIC_INSTALL_HOME=/cvmfs/soft.mugqic/CentOS6
     module use $MUGQIC_INSTALL_HOME/modulefiles
-    module load mugqic/python/2.7.14
+    module load mugqic/python/3.9.1
     module load mugqic/genpipes/<latest_version>
     export JOB_MAIL=<my.name@my.email.ca>
     export RAP_ID=<my-rap-id>


### PR DESCRIPTION
We need to update the version of the python module in the docs, since starting in v4 of GenPipes, we need to use python 3 instead of python 2 (as is currently indicated in this page). Maybe we can add a note to indicate that you need a different version of python depending on the version of GenPipes.