### PR TITLE
Removed CCRI example from FAQ to avoid confusion.

### DIFF
--- a/docs/source/faq/faq_new_users.rst
+++ b/docs/source/faq/faq_new_users.rst
@@ -27,17 +27,15 @@ To create a `new CCDB account`_, what should I fill in the form field: 'position
 
 **Response**
 
-Use the following option in the form:
+Chose the appropriate option in the form, for example:
 
 :: 
 
   external collaborator
 
-For the CCRI field, use the following as input:
+For the CCRI field, use the your sponsor's Compute Canada Role Identifier (CCRI) as input. 
+The CCRI has a structure similar to this: `abc-123-01`.
 
-:: 
-
-  bws-221-01
 
 What email ID should I use if I am an external collaborator?
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/docs/source/faq/faq_new_users.rst
+++ b/docs/source/faq/faq_new_users.rst
@@ -27,7 +27,7 @@ To create a `new CCDB account`_, what should I fill in the form field: 'position
 
 **Response**
 
-Chose the appropriate option in the form, for example:
+Choose an appropriate option in the form, for example:
 
 :: 
 


### PR DESCRIPTION
We need to remove Guillaume's CCRI ID from this page because we had an external user accidentally request sponsorship from our group because they got confused by this section. I edited the source file with a fix.