### PR TITLE
updating reference to GENPIPES_INIS variable for regular use instruct…

### DIFF
--- a/docs/source/common/gp_cluster_ini.inc
+++ b/docs/source/common/gp_cluster_ini.inc
@@ -1,5 +1,5 @@
 .. tip::
 
-     Depending upon the cluster where you are executing the pipeline, substitute the ``beluga.ini`` file name in the command with the appropriate *clustername.ini* file located in the ``$MUGQIC_PIPELINES_HOME/pipelines/common_ini`` folder.  
+     Depending upon the cluster where you are executing the pipeline, substitute the ``beluga.ini`` file name in the command with the appropriate *clustername.ini* file located in the ``$GENPIPES_INIS/common_ini`` folder.  
      
      For e.g., ``narval.ini``, ``cedar.ini``, or ``graham.ini``.

--- a/docs/source/deploy/access_gp_pre_installed.rst
+++ b/docs/source/deploy/access_gp_pre_installed.rst
@@ -114,7 +114,6 @@ To load the GenPipes modules, paste the following lines of code and save the fil
    ## GenPipes/MUGQIC genomes and modules
    export MUGQIC_INSTALL_HOME=/cvmfs/soft.mugqic/CentOS6
    module use $MUGQIC_INSTALL_HOME/modulefiles
-   module load mugqic/python/3.11.1
    module load mugqic/genpipes/<latest_version>
    export JOB_MAIL=<my.name@my.email.ca>
    export RAP_ID=<my-rap-id>
@@ -161,7 +160,6 @@ For MUGQIC analysts, add the following lines to your $HOME/.bash_profile:
   fi
 
   module use $MUGQIC_INSTALL_HOME/modulefiles $MUGQIC_INSTALL_HOME_DEV/modulefiles
-  module load mugqic/python/3.11.1
   module load mugqic/genpipes/<latest_version>
 
   export RAP_ID=<my-rap-id>

--- a/docs/source/deploy/dep_gp_cloud_gcp.rst
+++ b/docs/source/deploy/dep_gp_cloud_gcp.rst
@@ -127,8 +127,8 @@ Step 4: Create ChIP Sequencing pipeline execution command script as shown below:
 
   bash # You do not need this line if you did a logout login cycle
   # The next line generates the pipeline script
-  genpipes chipseq -c $MUGQIC_PIPELINES_HOME/pipelines/chipseq/chipseq.base.ini \
-  $MUGQIC_PIPELINES_HOME/pipelines/chipseq/chipseq.cedar.ini \
+  genpipes chipseq -c $GENPIPES_INIS/chipseq/chipseq.base.ini \
+  $GNEPIPES_INIS/common_ini/chipseq.cedar.ini \
   quick_start.ini \
   -j slurm \
   -r readsets.chipseqTest.chr22.tsv \

--- a/docs/source/deploy/dep_gp_local.rst
+++ b/docs/source/deploy/dep_gp_local.rst
@@ -16,22 +16,25 @@ For more details on other available options to deploy and access GenPipes you ma
 
 .. _docs_download_gp_src:
 
-Step 1: Download latest GenPipes sources
+Step 1: Download latest GenPipes sources and install with pip
 ----------------------------------------
 First of all, visit GenPipes `Download Page <https://bitbucket.org/mugqic/genpipes/downloads/>`_ and get a copy of the latest stable release software.  To fetch the most recent version of GenPipes, you may use the following command:
 
 ::
 
   git clone git@bitbucket.org:mugqic/genpipes.git
+  cd <bitbucket_repo>
+  pip install .
 
 Step 2: Setup environment variables
 -----------------------------------
 
-Add the following line in your your *$HOME/.bash_profile*: to set MUGQIC_PIPELINES_HOME to your local copy path. For example,
+Add the following lines in your your *$HOME/.bash_profile*: to set MUGQIC_PIPELINES_HOME to your local copy path. For example,
 
 ::
 
   export MUGQIC_PIPELINES_HOME=/path/to/your/local/genpipes
+  export GENPIPES_INIS=$MUGQIC_PIPELINES_HOME/genpipes/pipelines
 
 .. _accessing_sw_mod_genomes_local_dp:
 
@@ -267,7 +270,7 @@ You are now all set to use GenPipes pipelines. For each pipeline, you can get he
 
 ::
 
-  genpipes $MUGQIC_PIPELINES_HOME/pipelines/<pipeline_name>/<pipeline_name> --help
+  genpipes <pipeline_name> --help
 
 Running pipelines requires other inputs such as :ref:`Configuration File<docs_config_ini_file>`, :ref:`Readset File<docs_readset_file>` and :ref:`Design File<docs_design_file>`. For details on how to run individual pipelines you can see :ref:`Running GenPipes<docs_using_gp>` or :ref:`GenPipes User Guide<docs_user_guide>`.
 

--- a/docs/source/faq/faq_gp_dev.rst
+++ b/docs/source/faq/faq_gp_dev.rst
@@ -54,7 +54,7 @@ Now save the updated custom.ini file and mention it on the command line after th
 
 .. code::
 
-      genpipes chipseq -c $MUGQIC_PIPELINES_HOME/pipelines/chipseq/chipseq.base.ini $MUGQIC_PIPELINES_HOME/pipelines/common_ini/beluga.ini custom.ini -r readset.chipseq.txt -d design.chipseq.txt -s 1-20 -g chipseqScript.sh
+      genpipes chipseq -c $GENPIPES_INIS/chipseq/chipseq.base.ini $GENPIPES_INIS/common_ini/beluga.ini custom.ini -r readset.chipseq.txt -d design.chipseq.txt -s 1-20 -g chipseqScript.sh
 
       bash chipseqScript.sh
 

--- a/docs/source/get-started/concepts/config_ini_file.rst
+++ b/docs/source/get-started/concepts/config_ini_file.rst
@@ -52,20 +52,20 @@ Each pipeline has several configuration files in:
 ::
 
     #!bash
-    $MUGQIC_PIPELINES_HOME/pipelines/<pipeline_name>/<pipeline_name>.*.ini
+    $GENPIPES_INIS/<pipeline_name>/<pipeline_name>.*.ini
 
 A default configuration file (``.base.ini`` extension) is set for running on abacus cluster using Homo sapiens reference genome and must always be passed first to the ``--config`` option.
 
 You can also add a list of other configuration files to ``--config``. Files are read in the list order and each parameter value is overwritten if redefined in the next file.
 
-This is useful to customize settings for a specific cluster or genome. Each pipeline has a special configuration file for beluga and cedar clusters (``.beluga.ini`` and ``.cedar.ini`` extensions respectively) in the same directory. And various genome settings are available in ``$MUGQIC_PIPELINES_HOME/resources/genomes/config/``.
+This is useful to customize settings for a specific cluster or genome. Each pipeline has a special configuration file for beluga and cedar clusters (``.beluga.ini`` and ``.cedar.ini`` extensions respectively) in the same directory. And various genome settings are available in ``$MUGQIC_INSTALL_HOME/genomes/species/``.
 
 For example, to run the DNA-Seq pipeline on beluga cluster with Mus musculus reference genome:
 
 ::
 
     #!bash
-    genpipes $MUGQIC_PIPELINES_HOME/pipelines/dnaseq/dnaseq --config $MUGQIC_PIPELINES_HOME/pipelines/dnaseq/dnaseq.base.ini $MUGQIC_PIPELINES_HOME/pipelines/common_ini/beluga.ini $MUGQIC_PIPELINES_HOME/resources/genomes/config/Mus_musculus.GRCm38.ini [other options] -g genpipes_command_list.sh
+    genpipes $GENPIPES_INIS/dnaseq/dnaseq --config $GENPIPES_INIS/dnaseq/dnaseq.base.ini $GENPIPES_INIS/common_ini/beluga.ini $MUGQIC_INSTALL_HOME/genomes/species/Mus_musculus.GRCm38//Mus_musculus.GRCm38.ini [other options] -g genpipes_command_list.sh
     bash genpipes_command_list.sh
 
 

--- a/docs/source/get-started/concepts/readset_file.rst
+++ b/docs/source/get-started/concepts/readset_file.rst
@@ -219,17 +219,17 @@ Readsets refer to replicates that belong to a particular sample. If a sample was
 Creating a Readset File
 =======================
 
-If you have access to Abacus, we provide a script ``$MUGQIC_PIPELINES_HOME/utils/nanuq2mugqic_pipelines.py`` that can access your Nanuq data, creates symlinks to the data on Abacus and creates the Readset file for you.
+If you have access to Abacus, we provide a script ``nanuq2mugqic_pipelines.py`` that can access your Nanuq data, creates symlinks to the data on Abacus and creates the Readset file for you.
 
-If your data is on nanuq but you do not have access to Abacus, there is a helper script ``$MUGQIC_PIPELINES_HOME/utils/csvToreadset.R`` that takes a csv file downloadable from nanuq and creates the Readset file. However, you will have to download the data from Nanuq yourself.
+If your data is on nanuq but you do not have access to Abacus, there is a helper script ``csvToreadset.R`` that takes a csv file downloadable from nanuq and creates the Readset file. However, you will have to download the data from Nanuq yourself.
 
-If your data is not on nanuq, you will have to manually create the Readset file. You can use a template and enter your samples manually. Remember that it is a tab separated file. There is a helper ``$MUGQIC_PIPELINES_HOME/utils/mugqicValidator.py`` script that can validate the integrity of your readset file.
+If your data is not on nanuq, you will have to manually create the Readset file. You can use a template and enter your samples manually. Remember that it is a tab separated file. There is a helper ``mugqicValidator.py`` script that can validate the integrity of your readset file.
 
 .. note::
 
      **For abacus users with Nanuq readsets**
 
-     If your readsets belong to a `Nanuq <http://gqinnovationcenter.com/services/nanuq.aspx>`_ project, use ``$MUGQIC_PIPELINES_HOME/utils/nanuq2mugqic_pipelines.py`` script to automatically create a Readset File and symlinks to your readsets on abacus.
+     If your readsets belong to a `Nanuq <http://gqinnovationcenter.com/services/nanuq.aspx>`_ project, use ``nanuq2mugqic_pipelines.py`` script to automatically create a Readset File and symlinks to your readsets on abacus.
 
 .. Add a note from Francois via Paul S regarding Sample definition
 

--- a/docs/source/get-started/using_gp.rst
+++ b/docs/source/get-started/using_gp.rst
@@ -93,9 +93,9 @@ Please ensure you have access to the "beluga" server in `Digital Research Allian
 
 ::
 
-  genpipes chipseq -c $MUGQIC_PIPELINES_HOME/pipelines/chipseq/chipseq.base.ini $MUGQIC_PIPELINES_HOME/pipelines/common_ini/beluga.ini -r readset.chipseq.txt -s 1-15 -g chipseq_cmd.sh
+  genpipes chipseq -c $GENPIPES_INIS/chipseq/chipseq.base.ini $GENPIPES_INIS/common_ini/beluga.ini -r readset.chipseq.txt -s 1-15 -g chipseq_cmd.sh
 
-To understand what $MUGQIC_PIPELINES_HOME refers to, please see instructions on how to :ref:`access GenPipes on Compute Canada servers<docs_access_gp_pre_installed>`.
+To understand what $GENPIPES_INIS refers to, please see instructions on how to :ref:`access GenPipes on Compute Canada servers<docs_access_gp_pre_installed>`.
 
 In the command above, 
 
@@ -109,7 +109,7 @@ By default, Slurm scheduler is used when using the GenPipes deployment on the `D
 
 ::
 
-  genpipes chipseq -c $MUGQIC_PIPELINES_HOME/pipelines/chipseq/chiseq.base.ini $MUGQIC_PIPELINES_HOME/pipelines/common_ini/abacus.ini -r readset.chipseq.txt -s 1-15 -j pbs -g chipseq_cmd.sh
+  genpipes chipseq -c $GENPIPES_INIS/chipseq/chiseq.base.ini $GENPIPES_INIS/common_ini/abacus.ini -r readset.chipseq.txt -s 1-15 -j pbs -g chipseq_cmd.sh
 
 The above command generates a list of instructions that need to be executed to run the ChIP sequencing pipeline. These instructions are stored in the file:
 
@@ -208,7 +208,7 @@ Let us now run this RNA-Sequencing analysis on the *beluga* server at `Digital R
 
 ::
 
-  genpipes rnaseq -c $MUGQIC_PIPELINES_HOME/pipelines/rnaseq/rnaseq.base.ini $MUGQIC_PIPELINES_HOME/pipelines/common_ini/beluga.ini -r readset.rnaseq.txt -d design.rnaseq.txt -g rnaseqScript.txt
+  genpipes rnaseq -c $GENPIPES_INIS/rnaseq/rnaseq.base.ini $GENPIPES_INIS/common_ini/beluga.ini -r readset.rnaseq.txt -d design.rnaseq.txt -g rnaseqScript.txt
   bash rnaseqScript.txt
 
 The commands will be sent to the job queue and you will be notified once each step is done. If everything runs smoothly, you should get **MUGQICexitStatus:0** or **Exit_status=0.** If that is not the case, then an error has occurred after which the pipeline usually aborts. To examine the errors, check the content of the **job_output** folder.

--- a/docs/source/resources/testCommands.txt
+++ b/docs/source/resources/testCommands.txt
@@ -1,39 +1,39 @@
 ::
 
-    genpipes ampliconseq -c $MUGQIC_PIPELINES_HOME/pipelines/ampliconseq/ampliconseq.base.ini $MUGQIC_PIPELINES_HOME/pipelines/common_ini/beluga.ini -r readset.ampliconseq.txt -s 1-8 -g ampliconseqCommands.sh
+    genpipes ampliconseq -c $GENPIPES_INIS/ampliconseq/ampliconseq.base.ini $GENPIPES_INIS/common_ini/beluga.ini -r readset.ampliconseq.txt -s 1-8 -g ampliconseqCommands.sh
 
 :: 
 
-    genpipes chipseq -c $MUGQIC_PIPELINES_HOME/pipelines/chipseq/chipseq.base.ini $MUGQIC_PIPELINES_HOME/pipelines/common_ini/beluga.ini -r readsets.chipseq.txt -d design.chipseq.txt -s 1-19 -g chipseqCommands.sh
+    genpipes chipseq -c $GENPIPES_INIS/chipseq/chipseq.base.ini $GENPIPES_INIS/common_ini/beluga.ini -r readsets.chipseq.txt -d design.chipseq.txt -s 1-19 -g chipseqCommands.sh
 
 
 :: 
     
-    genpipes rnaseq -c $MUGQIC_PIPELINES_HOME/pipelines/rnaseq/rnaseq.base.ini $MUGQIC_PIPELINES_HOME/pipelines/common_ini/beluga.ini -r readset.rnaseq.txt -d design.rnaseq.txt -s 1-21 -g rnaseqCommands.sh
+    genpipes rnaseq -c $GENPIPES_INIS/rnaseq/rnaseq.base.ini $GENPIPES_INIS/common_ini/beluga.ini -r readset.rnaseq.txt -d design.rnaseq.txt -s 1-21 -g rnaseqCommands.sh
 
 
 ::
 
-    genpipes dnaseq -t germline_snv -c $MUGQIC_PIPELINES_HOME/pipelines/dnaseq/dnaseq.base.ini $MUGQIC_PIPELINES_HOME/pipelines/common_ini/beluga.ini -r readset.dnaseq.txt -s 1-27 -g dnaseqCommands_mugqic.sh
+    genpipes dnaseq -t germline_snv -c $GENPIPES_INIS/dnaseq/dnaseq.base.ini $GENPIPES_INIS/common_ini/beluga.ini -r readset.dnaseq.txt -s 1-27 -g dnaseqCommands_mugqic.sh
 
-    genpipes dnaseq -t germline_sv -c $MUGQIC_PIPELINES_HOME/pipelines/dnaseq/dnaseq.base.ini $MUGQIC_PIPELINES_HOME/pipelines/dnaseq/dnaseq.sv.ini $MUGQIC_PIPELINES_HOME/pipelines/common_ini/beluga.ini -r readset.dnaseq.txt -s 1-25 -g dnaseq_svCommands.sh
+    genpipes dnaseq -t germline_sv -c $GENPIPES_INIS/dnaseq/dnaseq.base.ini $GENPIPES_INIS/dnaseq/dnaseq.sv.ini $GENPIPES_INIS/common_ini/beluga.ini -r readset.dnaseq.txt -s 1-25 -g dnaseq_svCommands.sh
 
-    genpipes dnaseq -t germline_high_cov -c $MUGQIC_PIPELINES_HOME/pipelines/dnaseq/dnaseq.base.ini $MUGQIC_PIPELINES_HOME/pipelines/dnaseq/dnaseq.high_cov.ini  $MUGQIC_PIPELINES_HOME/pipelines/common_ini/beluga.ini -r readset.dnaseq.txt -s 1-15 -g dnaseq_high_coverageCommands.sh
+    genpipes dnaseq -t germline_high_cov -c $GENPIPES_INIS/dnaseq/dnaseq.base.ini $GENPIPES_INIS/dnaseq/dnaseq.high_cov.ini  $GENPIPES_INIS/common_ini/beluga.ini -r readset.dnaseq.txt -s 1-15 -g dnaseq_high_coverageCommands.sh
 
-    genpipes dnaseq -t somatic_ensemble -c $MUGQIC_PIPELINES_HOME/pipelines/dnaseq/dnaseq.base.ini $MUGQIC_PIPELINES_HOME/pipelines/dnaseq/dnaseq.cancer.ini  $MUGQIC_PIPELINES_HOME/pipelines/common_ini/beluga.ini -r readset.somatic_ensemble.txt -s 1-38 -g dnaseq_somatic_ensembleCommands.sh
+    genpipes dnaseq -t somatic_ensemble -c $GENPIPES_INIS/dnaseq/dnaseq.base.ini $GENPIPES_INIS/dnaseq/dnaseq.cancer.ini  $GENPIPES_INIS/common_ini/beluga.ini -r readset.somatic_ensemble.txt -s 1-38 -g dnaseq_somatic_ensembleCommands.sh
 
 
 ::
 
-    genpipes rnaseq_light -c $MUGQIC_PIPELINES_HOME/pipelines/rnaseq_light/rnaseq_light.base.ini $MUGQIC_PIPELINES_HOME/pipelines/common_ini/beluga.ini -r readset.rnaseq.txt -d design.rnaseq.txt -s 1-8 -g rnaseqLightCommands.sh
+    genpipes rnaseq_light -c $GENPIPES_INIS/rnaseq_light/rnaseq_light.base.ini $GENPIPES_INIS/common_ini/beluga.ini -r readset.rnaseq.txt -d design.rnaseq.txt -s 1-8 -g rnaseqLightCommands.sh
 
 
-    genpipes rnaseq_denovo_assembly -c $MUGQIC_PIPELINES_HOME/pipelines/rnaseq_denovo_assembly/rnaseq_denovo_assembly.base.ini $MUGQIC_PIPELINES_HOME/pipelines/common_ini/beluga.ini -r readset.rnaseq.txt -d design.rnaseq.txt -s 1-24 -g rnaseqDeNovoCommands.sh
+    genpipes rnaseq_denovo_assembly -c $GENPIPES_INIS/rnaseq_denovo_assembly/rnaseq_denovo_assembly.base.ini $GENPIPES_INIS/common_ini/beluga.ini -r readset.rnaseq.txt -d design.rnaseq.txt -s 1-24 -g rnaseqDeNovoCommands.sh
 
 
 :: 
 
-    genpipes methylseq -c $MUGQIC_PIPELINES_HOME/pipelines/methylseq/methylseq.base.ini $MUGQIC_PIPELINES_HOME/pipelines/common_ini/beluga.ini -r readset.methylseq.txt -s 1-15,17-18 > methylseq.sh
+    genpipes methylseq -c $GENPIPES_INIS/methylseq/methylseq.base.ini $GENPIPES_INIS/common_ini/beluga.ini -r readset.methylseq.txt -s 1-15,17-18 > methylseq.sh
 
 
 .. include:: /common/gp_cluster_ini.inc

--- a/docs/source/tutorials/genpipes_tutorial.rst
+++ b/docs/source/tutorials/genpipes_tutorial.rst
@@ -36,7 +36,6 @@ paste the following lines of code and save the file and Exit (Control + X):
     ## GenPipes/MUGQIC genomes and modules
     export MUGQIC_INSTALL_HOME=/cvmfs/soft.mugqic/CentOS6
     module use $MUGQIC_INSTALL_HOME/modulefiles
-    module load mugqic/python/3.11.1
     module load mugqic/genpipes/<latest_version>
     export JOB_MAIL=<my.name@my.email.ca>
     export RAP_ID=<my-rap-id>
@@ -133,19 +132,19 @@ GenPipes pipelines are multi-step pipelines that run several tools, each with it
 
 Each pipeline has several configuration/ini files in:
 
-**$MUGQIC_PIPELINES_HOME/pipelines/<pipeline_name>/<pipeline_name>.*.ini**
+**$GENPIPES_INIS/<pipeline_name>/<pipeline_name>.*.ini**
 
 For chipseq, that would be:
 
 .. code-block:: bash
 
-    ls $MUGQIC_PIPELINES_HOME/pipelines/chipseq/chipseq.base.ini
+    ls $GENPIPES_INIS/chipseq/chipseq.base.ini
 
 You will find a **<pipeline_name>.base.ini** as well as an ini file for particular servers like Beluga (<pipeline_name>.beluga.ini). The base.ini file has all the parameters needed by the pipeline but is optimized for usage on our own server, Abacus. To use the pipeline on beluga server, you will need to use both base.ini and beluga.ini, as such:
 
 .. code-block:: bash
 
-    genpipes chipseq -c $MUGQIC_PIPELINES_HOME/pipelines/chipseq/chipseq.base.ini $MUGQIC_PIPELINES_HOME/pipelines/common_ini/beluga.ini
+    genpipes chipseq -c $GENPIPES_INIS/chipseq/chipseq.base.ini $GENPIPES_INIS/common_ini/beluga.ini
 
 To change different parameters in the ini files, you can create your own ini file and overwrite the required parameters. For example, to change the number of threads for trimmomatic and hicup, I can create my own ini file: chipseq.test.ini
 and in it I can include the parameters to be changed:
@@ -164,7 +163,7 @@ then add my ini file after the other ini files:
 
 .. code-block:: bash
 
-    genpipes chipseq -c $MUGQIC_PIPELINES_HOME/pipelines/chipseq/chipseq.base.ini $MUGQIC_PIPELINES_HOME/pipelines/chipseq/chipseq.beluga.ini chipseq.test.ini [options]
+    genpipes chipseq -c $GENPIPES_INIS/chipseq/chipseq.base.ini $GENPIPES_INIS/chipseq/chipseq.beluga.ini chipseq.test.ini [options]
 
 For different species, we have custom ini files stored in **$MUGQIC_INSTALL_HOME/genomes/species/<species_of_interest>/**
 
@@ -174,7 +173,7 @@ To run the chipseq pipeline on mouse mm9, for example, you can do the following:
 
 .. code-block:: bash
 
-    genpipes chipseq -c $MUGQIC_PIPELINES_HOME/pipelines/chipseq/chipseq.base.ini $MUGQIC_PIPELINES_HOME/pipelines/chipseq/chipseq.beluga.ini $MUGQIC_INSTALL_HOME/genomes/species/Mus_musculus.mm9/Mus_musculus.mm9.ini [options]
+    genpipes chipseq -c $GENPIPES_INIS/chipseq/chipseq.base.ini $GENPIPES_INIS/chipseq/chipseq.beluga.ini $MUGQIC_INSTALL_HOME/genomes/species/Mus_musculus.mm9/Mus_musculus.mm9.ini [options]
 
 Readset File:
 -------------
@@ -232,11 +231,11 @@ Readsets refer to replicates that belong to a particular sample. If a sample was
 Creating a Readset File:
 ------------------------
 
-If you have access to Abacus, we provide a script **$MUGQIC_PIPELINES_HOME/utils/nanuq2mugqic_pipelines.py** that can access your Nanuq data, creates symlinks to the data on Abacus and creates the Readset file for you.
+If you have access to Abacus, we provide a script **nanuq2mugqic_pipelines.py** that can access your Nanuq data, creates symlinks to the data on Abacus and creates the Readset file for you.
 
-If your data is on nanuq but you do not have access to Abacus, there is a helper script **$MUGQIC_PIPELINES_HOME/utils/csvToreadset.R** that takes a csv file downloadable from nanuq and creates the Readset file. However, you will have to download the data from Nanuq yourself.
+If your data is on nanuq but you do not have access to Abacus, there is a helper script **csvToreadset.R** that takes a csv file downloadable from nanuq and creates the Readset file. However, you will have to download the data from Nanuq yourself.
 
-If your data is not on nanuq, you will have to manually create the Readset file. You can use a template and enter your samples manually. Remember that it is a tab separated file. There is a helper **$MUGQIC_PIPELINES_HOME/utils/mugqicValidator.py** script that can validate the integrity of your readset file.
+If your data is not on nanuq, you will have to manually create the Readset file. You can use a template and enter your samples manually. Remember that it is a tab separated file. There is a helper **mugqicValidator.py** script that can validate the integrity of your readset file.
 
 
 Design File:
@@ -279,7 +278,7 @@ We will run this analysis on Beluga server as follows:
 
 .. code-block:: bash
 
-    genpipes chipseq -c $MUGQIC_PIPELINES_HOME/pipelines/chipseq/chipseq.base.ini $MUGQIC_PIPELINES_HOME/pipelines/common_ini/beluga.ini -r readsets.chipseq.txt -s 1-15 -g chipseqcmd.sh
+    genpipes chipseq -c $GENPIPES_INIS/chipseq/chipseq.base.ini $GENPIPES_INIS/common_ini/beluga.ini -r readsets.chipseq.txt -s 1-15 -g chipseqcmd.sh
 
 **-c** defines the ini configuration files
 **-r** defines the readset file
@@ -291,7 +290,7 @@ This command works for servers using a SLURM scheduler like Cedar, Graham or Bel
 
 .. code-block:: bash
 
-    genpipes chipseq -c $MUGQIC_PIPELINES_HOME/pipelines/chipseq/chipseq.base.ini $MUGQIC_PIPELINES_HOME/pipelines/common_ini/abacus.ini -r readsets.chipseq.tsv -s 1-15 -j pbs -g chipseqcmd.sh
+    genpipes chipseq -c $GENPIPES_INIS/chipseq/chipseq.base.ini $GENPIPES_INIS/common_ini/abacus.ini -r readsets.chipseq.tsv -s 1-15 -j pbs -g chipseqcmd.sh
 
 To run it, use:
 
@@ -387,7 +386,7 @@ Looking at the contents of the design file, we see:
 We will run this analysis on the Beluga cluster as follows:
 ::
 
-	genpipes rnaseq -c $MUGQIC_PIPELINES_HOME/pipelines/rnaseq/rnaseq.base.ini $MUGQIC_PIPELINES_HOME/pipelines/common_ini/beluga.ini -r readset.rnaseq.txt -d design.rnaseq.txt -g rnaseq_commands.sh
+	genpipes rnaseq -c $GENPIPES_INIS/rnaseq/rnaseq.base.ini $GENPIPES_INIS/common_ini/beluga.ini -r readset.rnaseq.txt -d design.rnaseq.txt -g rnaseq_commands.sh
     bash rnaseq_commands.sh
 
 The commands will be sent to the job queue to be executed. You can check the progress of the jobs with
@@ -475,7 +474,7 @@ We will run this analysis on Beluga server as follows:
 
 .. code-block:: bash
 
-    genpipes chipseq -c $MUGQIC_PIPELINES_HOME/pipelines/chipseq/chipseq.base.ini $MUGQIC_PIPELINES_HOME/pipelines/common_ini/beluga.ini -r readsets.chipseqTest.chr22.tsv -d designfile_chipseq.chr22.txt -s 1-15 > chipseqScript.txt
+    genpipes chipseq -c $GENPIPES_INIS/chipseq/chipseq.base.ini $GENPIPES_INIS/common_ini/beluga.ini -r readsets.chipseqTest.chr22.tsv -d designfile_chipseq.chr22.txt -s 1-15 > chipseqScript.txt
     bash chipseqScript.txt
 
 The commands will be sent to the job queue and you will be notified once each step is done. If everything runs smoothly, you should get **MUGQICexitStatus:0** or **Exit_status=0**. If that is not the case, then an error has occurred after which the pipeline usually aborts. To examine the errors, check the content of the **job_output** folder.

--- a/docs/source/user_guide/pipelines/example_runs/ampliconseq.inc
+++ b/docs/source/user_guide/pipelines/example_runs/ampliconseq.inc
@@ -1,7 +1,7 @@
 ::
 
   genpipes ampliconseq \
-          -c $MUGQIC_PIPELINES_HOME/pipelines/ampliconseq/ampliconseq.base.ini $MUGQIC_PIPELINES_HOME/pipelines/common_ini/beluga.ini \
+          -c $GENPIPES_INIS/ampliconseq/ampliconseq.base.ini $GENPIPES_INIS/common_ini/beluga.ini \
           -r readset.ampliconseq.txt \
           -s 1-5 \
           -g ampliconseqCommands.sh 

--- a/docs/source/user_guide/pipelines/example_runs/chipseq.inc
+++ b/docs/source/user_guide/pipelines/example_runs/chipseq.inc
@@ -1,6 +1,6 @@
 ::
 
-  genpipes chipseq -c $MUGQIC_PIPELINES_HOME/pipelines/chipseq/chipseq.base.ini $MUGQIC_PIPELINES_HOME/pipelines/common_ini/beluga.ini -r readset.chipseq.txt -d design.chipseq.txt -s 1-20 -g chipseqScript.sh
+  genpipes chipseq -c $GENPIPES_INIS/pipelines/chipseq/chipseq.base.ini $GENPIPES_INIS/pipelines/common_ini/beluga.ini -r readset.chipseq.txt -d design.chipseq.txt -s 1-20 -g chipseqScript.sh
 
   bash chipseqScript.sh
 

--- a/docs/source/user_guide/pipelines/example_runs/covseq.inc
+++ b/docs/source/user_guide/pipelines/example_runs/covseq.inc
@@ -1,6 +1,6 @@
 ::
 
-  genpipes covseq -c $MUGQIC_PIPELINES_HOME/pipelines/covseq/covseq.base.ini $MUGQIC_PIPELINES_HOME/pipelines/common_ini/beluga.ini $MUGQIC_PIPELINES_HOME/pipelines/covseq/ARTIC_v4.1.ini -r readset.covseq.txt -g covseqCommands_mugqic.sh
+  genpipes covseq -c $GENPIPES_INIS/covseq/covseq.base.ini $GENPIPES_INIS/common_ini/beluga.ini $GENPIPES_INIS/covseq/ARTIC_v4.1.ini -r readset.covseq.txt -g covseqCommands_mugqic.sh
 
   bash covseqCommands_mugqic.sh
 

--- a/docs/source/user_guide/pipelines/example_runs/dnaseq_germ_high_cov.inc
+++ b/docs/source/user_guide/pipelines/example_runs/dnaseq_germ_high_cov.inc
@@ -1,6 +1,6 @@
 ::
 
-    genpipes dnaseq -t germline_high_cov -c $MUGQIC_PIPELINES_HOME/pipelines/dnaseq_high_coverage/dnaseq.base.ini $MUGQIC_PIPELINES_HOME/pipelines/common_ini/beluga.ini -j slurm -s 1-15 -g dna_commands.sh
+    genpipes dnaseq -t germline_high_cov -c $GENPIPES_INIS/dnaseq_high_coverage/dnaseq.base.ini $GENPIPES_INIS/common_ini/beluga.ini -j slurm -s 1-15 -g dna_commands.sh
 
     bash dna_commands.sh
 

--- a/docs/source/user_guide/pipelines/example_runs/dnaseq_germ_snv.inc
+++ b/docs/source/user_guide/pipelines/example_runs/dnaseq_germ_snv.inc
@@ -1,6 +1,6 @@
 ::
 
-  genpipes dnaseq -t germline_snv -c $MUGQIC_PIPELINES_HOME/pipelines/dnaseq_high_coverage/dnaseq.base.ini $MUGQIC_PIPELINES_HOME/pipelines/common_ini/beluga.ini -r readset.dnaseq.txt -j slurm -s 1-15 -g dna_commands.sh
+  genpipes dnaseq -t germline_snv -c $GENPIPES_INIS/dnaseq_high_coverage/dnaseq.base.ini $GENPIPES_INIS/common_ini/beluga.ini -r readset.dnaseq.txt -j slurm -s 1-15 -g dna_commands.sh
 
   bash dna_commands.sh
 

--- a/docs/source/user_guide/pipelines/example_runs/dnaseq_germ_sv.inc
+++ b/docs/source/user_guide/pipelines/example_runs/dnaseq_germ_sv.inc
@@ -1,6 +1,6 @@
 ::
 
-  genpipes dnaseq -t germline_sv -c $MUGQIC_PIPELINES_HOME/pipelines/dnaseq/dnaseq.base.ini $MUGQIC_PIPELINES_HOME/pipelines/dnaseq/dnaseq.sv.ini $MUGQIC_PIPELINES_HOME/pipelines/common_ini/beluga.ini -r readset.dnaseq.txt -j slurm -s 1-15 -g dna_commands.sh
+  genpipes dnaseq -t germline_sv -c $GENPIPES_INIS/dnaseq/dnaseq.base.ini $GENPIPES_INIS/dnaseq/dnaseq.sv.ini $GENPIPES_INIS/common_ini/beluga.ini -r readset.dnaseq.txt -j slurm -s 1-15 -g dna_commands.sh
 
   bash dna_commands.sh
 

--- a/docs/source/user_guide/pipelines/example_runs/dnaseq_som_ensemble.inc
+++ b/docs/source/user_guide/pipelines/example_runs/dnaseq_som_ensemble.inc
@@ -1,6 +1,6 @@
 ::
 
-  genpipes dnaseq -t somatic_ensemble -c $MUGQIC_PIPELINES_HOME/pipelines/dnaseq/dnaseq.base.ini $MUGQIC_PIPELINES_HOME/pipelines/dnaseq/dnaseq.cancer.ini $MUGQIC_PIPELINES_HOME/pipelines/common_ini/beluga.ini -r readset.somatic_ensemble.txt -p pairs.somatic_ensemble.csv -j slurm -s 1-15 -g dna_commands.sh
+  genpipes dnaseq -t somatic_ensemble -c $GENPIPES_INIS/dnaseq/dnaseq.base.ini $GENPIPES_INIS/dnaseq/dnaseq.cancer.ini $GENPIPES_INIS/common_ini/beluga.ini -r readset.somatic_ensemble.txt -p pairs.somatic_ensemble.csv -j slurm -s 1-15 -g dna_commands.sh
 
   bash dna_commands.sh
 

--- a/docs/source/user_guide/pipelines/example_runs/dnaseq_som_fastpass.inc
+++ b/docs/source/user_guide/pipelines/example_runs/dnaseq_som_fastpass.inc
@@ -1,6 +1,6 @@
 ::
 
-  genpipes dnaseq -t somatic_fastpass -c $MUGQIC_PIPELINES_HOME/pipelines/dnaseq/dnaseq.base.ini $MUGQIC_PIPELINES_HOME/pipelines/dnaseq/dnaseq.cancer.ini $MUGQIC_PIPELINES_HOME/pipelines/common_ini/beluga.ini -r readset.somatic_fastpass.txt -p pairs.somatic_fastpass.csv -j slurm -s 1-15 -g dna_commands.sh
+  genpipes dnaseq -t somatic_fastpass -c $GENPIPES_INIS/dnaseq/dnaseq.base.ini $GENPIPES_INIS/dnaseq/dnaseq.cancer.ini $GENPIPES_INIS/common_ini/beluga.ini -r readset.somatic_fastpass.txt -p pairs.somatic_fastpass.csv -j slurm -s 1-15 -g dna_commands.sh
 
   bash dna_commands.sh
 

--- a/docs/source/user_guide/pipelines/example_runs/dnaseq_som_sv.inc
+++ b/docs/source/user_guide/pipelines/example_runs/dnaseq_som_sv.inc
@@ -1,6 +1,6 @@
 ::
 
-  genpipes dnaseq -t somatic_sv -c $MUGQIC_PIPELINES_HOME/pipelines/dnaseq/dnaseq.base.ini $MUGQIC_PIPELINES_HOME/pipelines/dnaseq/dnaseq.cancer.ini $MUGQIC_PIPELINES_HOME/pipelines/common_ini/beluga.ini -r readset.somatic_sv.txt -p pairs.somatic_sv.csv -j slurm -s 1-15 -g dna_commands.sh
+  genpipes dnaseq -t somatic_sv -c $GENPIPES_INIS/dnaseq/dnaseq.base.ini $GENPIPES_INIS/dnaseq/dnaseq.cancer.ini $GENPIPES_INIS/common_ini/beluga.ini -r readset.somatic_sv.txt -p pairs.somatic_sv.csv -j slurm -s 1-15 -g dna_commands.sh
 
   bash dna_commands.sh
 

--- a/docs/source/user_guide/pipelines/example_runs/dnaseq_som_tum_only.inc
+++ b/docs/source/user_guide/pipelines/example_runs/dnaseq_som_tum_only.inc
@@ -1,6 +1,6 @@
 ::
 
-  genpipes dnaseq -t somatic_tumor_only -c $MUGQIC_PIPELINES_HOME/pipelines/dnaseq/dnaseq.base.ini $MUGQIC_PIPELINES_HOME/pipelines/common_ini/beluga.ini -r readset.somatic_tumor_only.txt -j slurm -s 1-15 -g dna_commands.sh
+  genpipes dnaseq -t somatic_tumor_only -c $GENPIPES_INIS/dnaseq/dnaseq.base.ini $GENPIPES_INIS/common_ini/beluga.ini -r readset.somatic_tumor_only.txt -j slurm -s 1-15 -g dna_commands.sh
 
   bash dna_commands.sh
 

--- a/docs/source/user_guide/pipelines/example_runs/methylseq.inc
+++ b/docs/source/user_guide/pipelines/example_runs/methylseq.inc
@@ -1,6 +1,6 @@
 ::
 
-  genpipes methylseq -c $MUGQIC_PIPELINES_HOME/pipelines/methylseq/methylseq.base.ini $MUGQIC_PIPELINES_HOME/pipelines/common_ini/beluga.ini -r readset.methylseq.txt -s 1-14 -g methylseq.sh
+  genpipes methylseq -c $GENPIPES_INIS/methylseq/methylseq.base.ini $GENPIPES_INIS/common_ini/beluga.ini -r readset.methylseq.txt -s 1-14 -g methylseq.sh
 
   bash methylseq.sh
 

--- a/docs/source/user_guide/pipelines/example_runs/nanopore_covseq.inc
+++ b/docs/source/user_guide/pipelines/example_runs/nanopore_covseq.inc
@@ -1,6 +1,6 @@
 ::
 
-  genpipes nanopore_covseq -c $MUGQIC_PIPELINES_HOME/pipelines/nanopore/nanopore.base.ini $MUGQIC_PIPELINES_HOME/pipelines/common_ini/beluga.ini $MUGQIC_PIPELINES_HOME/pipelines/nanopore_covseq/ARTIC_v4.1.ini -r readset.default.nanopore_covseq.txt -g nanopore_covseq_commands_mugqic.sh
+  genpipes nanopore_covseq -c $GENPIPES_INIS/nanopore/nanopore.base.ini $GENPIPES_INIS/common_ini/beluga.ini $GENPIPES_INIS/nanopore_covseq/ARTIC_v4.1.ini -r readset.default.nanopore_covseq.txt -g nanopore_covseq_commands_mugqic.sh
 
   bash nanopore_covseq_commands.sh
 

--- a/docs/source/user_guide/pipelines/example_runs/rnaseq.inc
+++ b/docs/source/user_guide/pipelines/example_runs/rnaseq.inc
@@ -1,6 +1,6 @@
 ::
 
-  genpipes rnaseq -c $MUGQIC_PIPELINES_HOME/pipelines/rnaseq/rnaseq.base.ini $MUGQIC_PIPELINES_HOME/pipelines/common_ini/beluga.ini -r readset.rnaseq.txt -d design.rnaseq.txt -s 1-24 -j slurm -g commands.txt
+  genpipes rnaseq -c $GENPIPES_INIS/rnaseq/rnaseq.base.ini $GENPIPES_INIS/common_ini/beluga.ini -r readset.rnaseq.txt -d design.rnaseq.txt -s 1-24 -j slurm -g commands.txt
 
   bash commands.txt
 

--- a/docs/source/user_guide/pipelines/example_runs/rnaseq_denovo.inc
+++ b/docs/source/user_guide/pipelines/example_runs/rnaseq_denovo.inc
@@ -1,6 +1,6 @@
 ::
 
-  genpipes rnaseq_denovo_assembly -c $MUGQIC_PIPELINES_HOME/pipelines/rnaseq_denovo_assembly/rnaseq_denovo_assembly.base.ini $MUGQIC_PIPELINES_HOME/pipelines/common_ini/beluga.ini -r readset.rnaseq.txt -d design.rnaseq.txt -s 1-23 -g rnaseqDeNovoCommands.sh
+  genpipes rnaseq_denovo_assembly -c $GENPIPES_INIS/rnaseq_denovo_assembly/rnaseq_denovo_assembly.base.ini $GENPIPES_INIS/common_ini/beluga.ini -r readset.rnaseq.txt -d design.rnaseq.txt -s 1-23 -g rnaseqDeNovoCommands.sh
 
   bash rnaseqDeNovoCommands.sh
 

--- a/docs/source/user_guide/pipelines/example_runs/rnaseq_light.inc
+++ b/docs/source/user_guide/pipelines/example_runs/rnaseq_light.inc
@@ -1,5 +1,5 @@
 ::
 
-  genpipes rnaseq_light -c $MUGQIC_PIPELINES_HOME/pipelines/rnaseq_light/rnaseq_light.base.ini $MUGQIC_PIPELINES_HOME/pipelines/common_ini/beluga.ini -r readset.rnaseq.txt -d design.rnaseq.txt -g rnaseqCommands.sh
+  genpipes rnaseq_light -c $GENPIPES_INIS/rnaseq_light/rnaseq_light.base.ini $GENPIPES_INIS/common_ini/beluga.ini -r readset.rnaseq.txt -d design.rnaseq.txt -g rnaseqCommands.sh
 
   bash rnaseqCommands.sh

--- a/docs/source/user_guide/pipelines/gp_rnaseq_light.rst
+++ b/docs/source/user_guide/pipelines/gp_rnaseq_light.rst
@@ -34,7 +34,7 @@ RNA Sequencing (Light) Pipeline
 
             .. tip::
 
-                 Replace ``beluga.ini`` file name in the command above with the appropriate *clustername.ini* file located in the ``$MUGQIC_PIPELINES_HOME/pipelines/common_ini`` folder, depending upon the cluster where you are executing the pipeline.  For e.g., ``narval.ini``, ``cedar.ini``, ``graham.ini`` or ``narval.ini``.
+                 Replace ``beluga.ini`` file name in the command above with the appropriate *clustername.ini* file located in the ``$GENPIPES_INIS/pipelines/common_ini`` folder, depending upon the cluster where you are executing the pipeline.  For e.g., ``narval.ini``, ``cedar.ini``, ``graham.ini`` or ``narval.ini``.
 
             .. include:: /user_guide/pipelines/notes/scriptfile_deprecation.inc
 


### PR DESCRIPTION
We're adding a new variable 'GENPIPES_INIS' to access the config files used in commands. This is to make the usage a bit more streamlined and remove the reference to MUGQIC, which is outdated. The old variable will still be accessible and is still in use for instructions on how to deploy genpipes locally, in the cloud, or in a container. 